### PR TITLE
Move BamReader forward declaration into SeqLib namespace

### DIFF
--- a/SeqLib/BamReader.h
+++ b/SeqLib/BamReader.h
@@ -11,9 +11,10 @@ extern "C" {
 int hts_useek(htsFile *file, long uoffset, int where);
 }
 
-class BamReader;
 
 namespace SeqLib {
+
+  class BamReader;
 
   typedef SeqPointer<hts_idx_t> SharedIndex; ///< Shared pointer to the HTSlib index struct
 


### PR DESCRIPTION
This prevents compilation errors such as the following:

```
bam_reader.cpp: In function ‘int main()’:
bam_reader.cpp:8:1: error: reference to ‘BamReader’ is ambiguous
 BamReader bw;
 ^~~~~~~~~
In file included from bam_reader.cpp:1:0:
/home-1/dbaker49@jhu.edu/work/db/code/sl/SeqLib/SeqLib/BamReader.h:14:7: note: candidates are: class BamReader
 class BamReader;
       ^~~~~~~~~
/home-1/dbaker49@jhu.edu/work/db/code/sl/SeqLib/SeqLib/BamReader.h:116:7: note:                 class SeqLib::BamReader
 class BamReader {

```

This only occurs when `using namespace SeqLib`. It seems that the forward declaration was for a distinct type because it occurred in a different namespace.