### PR TITLE
Apply m_cram_reference to bams

### DIFF
--- a/src/BamReader.cpp
+++ b/src/BamReader.cpp
@@ -148,6 +148,7 @@ void BamReader::Reset() {
       return false;
     
     _Bam new_bam(bam);
+    if (!m_cram_reference.empty()) new_bam.m_cram_reference = m_cram_reference;
     new_bam.m_region = &m_region;
     bool success = new_bam.open_BAM_for_reading(pool);
     m_bams.insert(std::pair<std::string, _Bam>(bam, new_bam));


### PR DESCRIPTION
See #34 

The value of `_Bam::m_cram_reference` is never meaningfully propagated to the underlying htslib bam constructs.

If `BamReader::SetCramReference` is called before any crams are opened, `BamReader::m_cram_reference` is never passed to new bams in `BamReader::Open`, so the new `_Bam` never calls `htslib::cram_load_reference`.

This PR adds a single line so that `m_cram_reference` is passed into new bams when opened.

This PR does not fix the case where bams have already opened via `BamReader::Open` before setting a reference.  It will probably involve copying [this code segment](https://github.com/walaj/SeqLib/blob/master/src/BamReader.cpp#L199) into `BamReader::SetCramReference`, but I didn't want to just start duplicating code blocks in case you wanted to move that into it's own function.