### PR TITLE
kseq.h discarded the unaligned sequence name marker @, so we should a…

### DIFF
--- a/SeqLib/UnalignedSequence.h
+++ b/SeqLib/UnalignedSequence.h
@@ -59,7 +59,7 @@ namespace SeqLib {
      * @param us UnalignedSequence
      */
     friend std::ostream& operator<<(std::ostream& os, const SeqLib::UnalignedSequence& us){
-        os << us.Name << " " << us.Com << "\n";
+        os << "@" << us.Name << " " << us.Com << "\n";
         os << us.Seq << "\n+\n";
         os << us.Qual << "\n";
         return os;


### PR DESCRIPTION
fix bug in writing a unaligned sequence to stream