### PR TITLE
Update makefile.am to build libs in lib/ rather than bin/

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign
 SUBDIRS = bwa htslib fermi-lite src
 
 install:  
-	mkdir -p bin && cp src/libseqlib.a fermi-lite/libfml.a bwa/libbwa.a htslib/libhts.a bin 
+	mkdir -p lib && cp src/libseqlib.a fermi-lite/libfml.a bwa/libbwa.a htslib/libhts.a lib
 
 seqtools:
 	mkdir -p bin && cd src/seqtools && make && mv seqtools ../../bin


### PR DESCRIPTION
This modifies the Makefile.am to place libraries in ${prefix}/lib, rather then ${prefix}/bin. I didn't test if this had any side effects, but I think it should work so long as all the system paths (i.e. LD_LIBRARY_PATH, PATH) are as expected.