### PR TITLE
Try to infer b37 style contig names when constructing GenomicRegion from strings

### DIFF
--- a/SeqLib/GenomicRegion.h
+++ b/SeqLib/GenomicRegion.h
@@ -7,6 +7,9 @@
 #include <utility>
 #include <list>
 #include <cstring>
+#ifdef HAVE_C11
+#include <regex>
+#endif
 
 #include "SeqLib/SeqLibCommon.h"
 #include "SeqLib/SeqLibUtils.h"

--- a/SeqLib/GenomicRegion.h
+++ b/SeqLib/GenomicRegion.h
@@ -7,9 +7,6 @@
 #include <utility>
 #include <list>
 #include <cstring>
-#ifdef HAVE_C11
-#include <regex>
-#endif
 
 #include "SeqLib/SeqLibCommon.h"
 #include "SeqLib/SeqLibUtils.h"

--- a/src/GenomicRegion.cpp
+++ b/src/GenomicRegion.cpp
@@ -3,6 +3,9 @@
 #include <cassert>
 #include <stdexcept>
 #include <climits>
+#ifdef HAVE_C11
+#include <regex>
+#endif
 
 // 4 billion
 #define END_MAX 4000000000

--- a/src/GenomicRegion.cpp
+++ b/src/GenomicRegion.cpp
@@ -269,6 +269,15 @@ int32_t GenomicRegion::DistanceBetweenEnds(const GenomicRegion &gr) const {
       return;
     } else {
       chr = hdr.Name2ID(tchr); //bam_name2id(hdr.get(), tchr.c_str());
+
+      // if tchr was not found in sequence dictionary, it's possible that we're 
+      // specifying our contigs in b37 style whereas dict is hg** style;
+      // let's attempt to automatically convert [0-9XY]+ -> chr[0-9XY]+
+#ifdef HAVE_C11
+      if(chr == -1 && std::regex_match(tchr, std::regex("([0-9XY]+)"))) {
+	 chr = hdr.Name2ID("chr" + tchr);
+      }
+#endif
     }
   }
 }

--- a/src/GenomicRegion.cpp
+++ b/src/GenomicRegion.cpp
@@ -277,7 +277,7 @@ int32_t GenomicRegion::DistanceBetweenEnds(const GenomicRegion &gr) const {
       // specifying our contigs in b37 style whereas dict is hg** style;
       // let's attempt to automatically convert [0-9XY]+ -> chr[0-9XY]+
 #ifdef HAVE_C11
-      static std::regex b37_regex("([0-9XY]+)");
+      static std::regex b37_regex("[0-9XY]+");
       if(chr == -1 && std::regex_match(tchr, b37_regex)) {
 	 chr = hdr.Name2ID("chr" + tchr);
       }

--- a/src/GenomicRegion.cpp
+++ b/src/GenomicRegion.cpp
@@ -277,7 +277,8 @@ int32_t GenomicRegion::DistanceBetweenEnds(const GenomicRegion &gr) const {
       // specifying our contigs in b37 style whereas dict is hg** style;
       // let's attempt to automatically convert [0-9XY]+ -> chr[0-9XY]+
 #ifdef HAVE_C11
-      if(chr == -1 && std::regex_match(tchr, std::regex("([0-9XY]+)"))) {
+      static std::regex b37_regex("([0-9XY]+)");
+      if(chr == -1 && std::regex_match(tchr, b37_regex)) {
 	 chr = hdr.Name2ID("chr" + tchr);
       }
 #endif


### PR DESCRIPTION
When creating a GenomicRegion from strings contig/start/end, see if the primary contig names can can be easily mapped from b37 style -> hgXX style, i.e. [0-9XY]+ -> chr[0-9XY]+

Note that this will only work if using ≥C++11, since it depends on STL regex functionality introduced in C++11. I've thus added the appropriate language scope guards.