### PR TITLE
Avoid using private HTSlib headers and functions

### DIFF
--- a/SeqLib/BamWalker.h
+++ b/SeqLib/BamWalker.h
@@ -11,11 +11,6 @@
 #define INT32_MAX 0x7fffffffL
 #endif
 
-extern "C" {
-#include "htslib/cram/cram.h"
-#include "htslib/cram/cram_io.h"
-}
-
 struct idx_delete {
   void operator()(hts_idx_t* x) { if (x) hts_idx_destroy(x); }
 };

--- a/src/BamReader.cpp
+++ b/src/BamReader.cpp
@@ -198,9 +198,7 @@ BamReader::BamReader() {}
 
     // open cram reference
     if (!m_cram_reference.empty()) {
-      char * m_cram_reference_cstr = strdup(m_cram_reference.c_str());
-      int ret = cram_load_reference(fp->fp.cram, m_cram_reference_cstr);
-      free(m_cram_reference_cstr);
+      int ret = hts_set_fai_filename(fp.get(), m_cram_reference.c_str());
       if (ret < 0) 
 	throw std::invalid_argument("Could not read reference genome " + m_cram_reference + " for CRAM opt");
     }


### PR DESCRIPTION
Use a public HTSlib API function to set the CRAM reference file rather than an internal CRAM-only function that is private to HTSlib.

Happily there is only one instance of a private HTSlib function being used. Fixes #21.