### PR TITLE
Added GFA output method call to FermiAssembler

### DIFF
--- a/SeqLib/FermiAssembler.h
+++ b/SeqLib/FermiAssembler.h
@@ -114,6 +114,7 @@ namespace SeqLib {
     /** Return the number of sequences that are controlled by this assembler */
     size_t NumSequences() const { return n_seqs; }
 
+    void WriteGFA(std::ostream &out);
   private:
 
     // reads to assemble

--- a/src/FermiAssembler.cpp
+++ b/src/FermiAssembler.cpp
@@ -183,8 +183,7 @@ SeqLib::FermiAssembler::WriteGFA(std::ostream &out)
   for (i = 0; i < n_utg; ++i) {
     const fml_utg_t *u = m_utgs + i;
     out << "S\t" << i << "\t";
-    out << u->seq << std::endl;
-    out << "\tLN:i:" << u->len << "\tRC:i:" << u->nsr << "\tPD:Z:";
+    out << u->seq << "\tLN:i:" << u->len << "\tRC:i:" << u->nsr << "\tPD:Z:";
     out << u->cov << std::endl;
     for (j = 0; j < u->n_ovlp[0] + u->n_ovlp[1]; ++j) {
       fml_ovlp_t *o = &u->ovlp[j];

--- a/src/FermiAssembler.cpp
+++ b/src/FermiAssembler.cpp
@@ -174,3 +174,25 @@ namespace SeqLib {
   }
   
 }
+
+void
+SeqLib::FermiAssembler::WriteGFA(std::ostream &out)
+{
+  int i, j;
+  out << "H\tVN:Z:1.0" << std::endl;
+  for (i = 0; i < n_utg; ++i) {
+    const fml_utg_t *u = m_utgs + i;
+    out << "S\t" << i << "\t";
+    out << u->seq << std::endl;
+    out << "\tLN:i:" << u->len << "\tRC:i:" << u->nsr << "\tPD:Z:";
+    out << u->cov << std::endl;
+    for (j = 0; j < u->n_ovlp[0] + u->n_ovlp[1]; ++j) {
+      fml_ovlp_t *o = &u->ovlp[j];
+      if (i < o->id) {
+        out << "L\t" << i << "\t"
+            << "+-"[!o->from] << "\t" << o->id << "\t"
+            << "+-"[o->to] << "\t" << o->len << "M" << std::endl;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi, I think this feature is needed for the FermiAssembler to be feature complete. The unitig graph is very useful for walking, and applying other algorithms.