### PR TITLE
Add LastFlag() to BamRecord

### DIFF
--- a/SeqLib/BamRecord.h
+++ b/SeqLib/BamRecord.h
@@ -414,6 +414,9 @@ class BamRecord {
   
   /** Check if this read is first in pair */
   inline bool FirstFlag() const { return (b->core.flag&BAM_FREAD1); }
+
+  /** Check if this read is last in pair */
+  inline bool LastFlag() const { return (b->core.flag&BAM_FREAD2); }
   
   /** Get the qname of this read as a string */
   inline std::string Qname() const { return std::string(bam_get_qname(b)); }


### PR DESCRIPTION
Currently, BamRecord objects have a FirstRead() method that returns `true` if the 0x40 bit of the FLAG field is set. This PR proposes adding a corresponding LastRead() method that returns `true` if the 0x80 bit is set.

Per the [SAM spec](http://samtools.github.io/hts-specs/SAMv1.pdf):

> Bits 0x40 and 0x80 reflect the read ordering within each template inherent in the sequencing
technology used.13 If 0x40 and 0x80 are both set, the read is part of a linear template, but it is
neither the first nor the last read. If both 0x40 and 0x80 are unset, the index of the read in the
template is unknown. This may happen for a non-linear template or when this information is lost
during data processing.